### PR TITLE
Expose the underlying UITextView as contentView, deprecate text view customization properties

### DIFF
--- a/demo/demo/ViewController.swift
+++ b/demo/demo/ViewController.swift
@@ -16,9 +16,14 @@ class ViewController: UIViewController
   override func viewDidLoad()
   {
     super.viewDidLoad()
-    
+        
     textView.furiganas = exampleFuriganas
     textView.contents = exampleContents
+    
+    // after the contents has been set, the `contentView` will be referencing the underlying UITextView
+    // we can customize the UITextView the way we want
+    textView.contentView?.isScrollEnabled = false
+    textView.contentView?.backgroundColor = UIColor(white: 0.9, alpha: 1)
   }
 
 }

--- a/src/FuriganaTextView.swift
+++ b/src/FuriganaTextView.swift
@@ -21,8 +21,9 @@ open class FuriganaTextView: UIView
   
   // MARK: - Public
   
-  open var scrollEnabled: Bool = true
-  open var alignment: NSTextAlignment = .left
+  public var contentView: UITextView? {
+    return underlyingTextView
+  }
   
   open var furiganaEnabled = true
   open var furiganaTextStyle = FuriganaTextStyle(hostingLineHeightMultiple: 1.6, textOffsetMultiple: 0)
@@ -143,6 +144,14 @@ open class FuriganaTextView: UIView
 
     return vertical + horizontal
   }
+  
+  // MARK: - Deprecated
+  
+  @available(*, deprecated)
+  open var scrollEnabled: Bool = true
+  
+  @available(*, deprecated)
+  open var alignment: NSTextAlignment = .left
   
 }
 


### PR DESCRIPTION
The `FuriganaTextView` class now has a new read-only property `contentView` to reference the underlying `UITextView` that dose the actual text rendering work.

The property will return a valid `UITextView` after the `contents` has been set.
**Note:** If the `contents` has never been set, `contentView` will return `nil`.

The previous text view customization properties are now **deprecated**, and **will be removed** in the next release. The properties include:

- `scrollEnabled`
- `alignment`

Please use the `contentView` to customize the text view instead.